### PR TITLE
 balena-image-initramfs: remove recovery and mdraid modules

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,1 +1,4 @@
 PACKAGE_INSTALL:append = " tegra-firmware-xusb"
+
+PACKAGE_INSTALL:remove = " mdraid"
+PACKAGE_INSTALL:remove = " initramfs-module-recovery"


### PR DESCRIPTION
The Jetson family does not have enough space to increase the initramfs size and the recovery functionality does not fit in the current maximum space allocation of 32MB.

Changelog-entry: remove recovery module from balena-image-initramfs


Internal thread: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/Yocto.20build.20failures/near/342653275