### PR TITLE
balena-image: Shrink partition sizes for the Orin NX

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.bbappend
@@ -11,12 +11,12 @@ BALENA_BOOT_SIZE:jetson-xavier-nx-devkit-emmc = "121440"
 BALENA_BOOT_SIZE:jetson-xavier-nx-devkit = "121440"
 
 # The Orin NX runs on a NVME which offers plenty of space
-BALENA_BOOT_SIZE:jetson-orin-nx-xavier-nx-devkit = "242880"
+BALENA_BOOT_SIZE:jetson-orin-nx-xavier-nx-devkit = "121440"
 
 IMAGE_ROOTFS_SIZE:jetson-xavier = "487424"
 IMAGE_ROOTFS_SIZE:jetson-xavier-nx-devkit-emmc = "733184"
 IMAGE_ROOTFS_SIZE:jetson-xavier-nx-devkit = "733184"
-IMAGE_ROOTFS_SIZE:jetson-orin-nx-xavier-nx-devkit = "1228800"
+IMAGE_ROOTFS_SIZE:jetson-orin-nx-xavier-nx-devkit = "83886080"
 
 BALENA_BOOT_PARTITION_FILES:append = " \
     bootfiles/EFI/BOOT/BOOTAA64.efi:/EFI/BOOT/BOOTAA64.efi \


### PR DESCRIPTION
The image-maker appears to fail in staging,
perhaps the image is too large. Let's shrink the
partition sizes a bit to investigate the root cause.

Changeog-entry: balena-image: Shrink partition sizes