### PR TITLE
linux-tegra: On the Orin AGX use rtc0 as system clock

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -92,6 +92,11 @@ BALENA_CONFIGS[xudc] = " \
     CONFIG_USB_TEGRA_XUDC=m \
 "
 
+BALENA_CONFIGS:append:jetson-agx-orin-devkit = " rtc"
+BALENA_CONFIGS[rtc] = " \
+    CONFIG_RTC_HCTOSYS_DEVICE="rtc0" \
+"
+
 L4TVER=" l4tver=${L4T_VERSION}"
 
 KERNEL_ARGS = " firmware_class.path=/etc/firmware fbcon=map:0 "


### PR DESCRIPTION
Relates to: https://jel.ly.fish/support-thread-time-synchronization-moving-offline-5949256

The Orin AGX devkit has two RTC clocks, one in the SOM and one in the carrier board. The BSP defaults to using the one in the SOM but only the one in the carrier board in connected to a backup battery and is able to keep time between reboots.

Changelog-entry: Use battery backed-up RTC in Orin AGX devkit