### PR TITLE
linux-tegra: Update rtc0 from system clock on the Orin AGX

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -76,6 +76,7 @@ BALENA_CONFIGS[xudc] = " \
 BALENA_CONFIGS:append:jetson-agx-orin-devkit = " rtc"
 BALENA_CONFIGS[rtc] = " \
     CONFIG_RTC_HCTOSYS_DEVICE="rtc0" \
+    CONFIG_RTC_SYSTOHC_DEVICE="rtc0" \
 "
 
 L4TVER=" l4tver=${L4T_VERSION}"


### PR DESCRIPTION
Configure `CONFIG_RTC_SYSTOHC_DEVICE` to use `rtc0` as 336d198b079a03941344410806bb449b90b4dbe2 only changed the `HCTOSYS` direction.