### PR TITLE
Add UEFI firmware version check

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/balena-rollback/balena-rollback.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/balena-rollback/balena-rollback.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/layers/meta-balena-jetson/recipes-core/balena-rollback/files/rollback-board-healthcheck
+++ b/layers/meta-balena-jetson/recipes-core/balena-rollback/files/rollback-board-healthcheck
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -o errexit
+
+fw_version=$(/usr/sbin/nvbootctrl dump-slots-info | grep -E -o 'Current version: [0-9]+[.]+[0-9]' | awk '{print $3}')
+kernel_l4t=$(uname -r | grep -E -o 'l4t-r[0-9]+[.]+[0-9]' | cut -d "r" -f 2)
+
+echo "Rollback: UEFI firmware L4T version: ${fw_version}"
+echo "Rollback: Kernel L4T version: ${kernel_l4t}"
+
+if [[ "$fw_version" == "$kernel_l4t" ]]; then
+    echo "Rollback: L4T versions match"
+else
+    echo "Rollback: L4T versions do not match"
+    exit 1
+fi


### PR DESCRIPTION
This PR adds a script which compares the UEFI firmware L4T version with the Kernel L4T version.

Since L4T releases are in the form 35.2.1, 35.3.1, 35.4.1, and uname only reports major and the minor numbers, we use them in the comparison of the version reported by the Jetson tool named `nvbootctrl`

Tested on Jetson AGX Orin Devkit 32GB