### PR TITLE
Use meta tegra efivars scripts

### DIFF
--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-agx-orin-devkit/after
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-agx-orin-devkit/after
@@ -17,6 +17,14 @@ platform_spec_efivar="${efivars_dir}TegraPlatformSpec-781e084c-a330-417c-b678-38
 platform_compat_spec_efivar="${efivars_dir}TegraPlatformCompatSpec-781e084c-a330-417c-b678-38e696380cb9"
 os_indications_efivar="${efivars_dir}OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 tmp_file="/tmp/platformspecfile.bin"
+device_type="jetson-agx-orin-devkit"
+
+source /usr/bin/uefi_common.func
+
+boardspec=$(tegra-boardspec 2>/dev/null)
+TegraPlatformSpec="${boardspec}-${device_type}-"
+compatspec=$(echo "$boardspec" | gen_compat_spec)
+TegraPlatformCompatSpec="${compatspec}-${device_type}-"
 
 write_jetson_update_efivars() {
     echo "Writing of jetson efivars triggered from old OS hook"
@@ -25,7 +33,7 @@ write_jetson_update_efivars() {
         # causing the entire hook to fail
         if [ ! -e ${platform_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3701-500-0000-J.0-1-1-jetson-agx-orin-devkit-" >> ${tmp_file}
+            printf "%s" "${TegraPlatformSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_spec_efivar}
             echo "PlatformSpec variable created"
         else
@@ -34,7 +42,7 @@ write_jetson_update_efivars() {
 
         if [ ! -e ${platform_compat_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3701-000-0000--1-0-jetson-agx-orin-devkit-" >> ${tmp_file}
+            printf "%s" "${TegraPlatformCompatSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_compat_spec_efivar}
             echo "PlatformCompatSpec variable created"
         else

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-orin-nano-devkit-nvme/after
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-orin-nano-devkit-nvme/after
@@ -18,6 +18,16 @@ platform_compat_spec_efivar="${efivars_dir}TegraPlatformCompatSpec-781e084c-a330
 os_indications_efivar="${efivars_dir}OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 tmp_file="/tmp/platformspecfile.bin"
 
+device_type="jetson-orin-nano-devkit"
+
+source /usr/bin/uefi_common.func
+
+boardspec=$(tegra-boardspec 2>/dev/null)
+TegraPlatformSpec="${boardspec}-${device_type}-"
+compatspec=$(echo "$boardspec" | gen_compat_spec)
+TegraPlatformCompatSpec="${compatspec}-${device_type}-"
+
+
 write_jetson_update_efivars() {
     echo "Writing of jetson efivars triggered from old OS hook"
     if [ -d $efivars_dir ]; then
@@ -25,7 +35,7 @@ write_jetson_update_efivars() {
         # causing the entire hook to fail
         if [ ! -e ${platform_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3767-300-0005-K.2-1-1-jetson-orin-nano-devkit-" >> ${tmp_file}
+            printf "%s" "${TegraPlatformSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_spec_efivar}
             echo "PlatformSpec variable created"
         else
@@ -34,7 +44,7 @@ write_jetson_update_efivars() {
 
         if [ ! -e ${platform_compat_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3767--0005--1--jetson-orin-nano-devkit-" >> ${tmp_file}
+            printf "%s" "${TegraPlatformCompatSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_compat_spec_efivar}
             echo "PlatformCompatSpec variable created"
         else

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-orin-nx-xavier-nx-devkit/after
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/98-efivars-orin-nx-xavier-nx-devkit/after
@@ -18,6 +18,17 @@ platform_compat_spec_efivar="${efivars_dir}TegraPlatformCompatSpec-781e084c-a330
 os_indications_efivar="${efivars_dir}OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 tmp_file="/tmp/platformspecfile.bin"
 
+# As per the UpdateAndRedundancy bup gen docs,
+# the Orin NX uses the Orin Nano type
+device_type="jetson-orin-nano-devkit"
+
+source /usr/bin/uefi_common.func
+
+boardspec=$(tegra-boardspec 2>/dev/null)
+TegraPlatformSpec="${boardspec}-${device_type}-"
+compatspec=$(echo "$boardspec" | gen_compat_spec)
+TegraPlatformCompatSpec="${compatspec}-${device_type}-"
+
 write_jetson_update_efivars() {
     echo "Writing of jetson efivars triggered from old OS hook"
     if [ -d $efivars_dir ]; then
@@ -25,7 +36,7 @@ write_jetson_update_efivars() {
         # causing the entire hook to fail
         if [ ! -e ${platform_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3767-ES1-0000-A.3-1-0-jetson-orin-nx-xavier-nx-devkit" >> ${tmp_file}
+            printf "%s" "${TegraPlatformSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_spec_efivar}
             echo "PlatformSpec variable created"
         else
@@ -34,7 +45,7 @@ write_jetson_update_efivars() {
 
         if [ ! -e ${platform_compat_spec_efivar} ]; then
             printf "\x07\x00\x00\x00" > ${tmp_file}
-            printf "%s" "3767-000-0000--1-0-jetson-orin-nano-devkit-" >> ${tmp_file}
+            printf "%s" "${TegraPlatformCompatSpec}" >> ${tmp_file}
             dd if=${tmp_file} of=${platform_compat_spec_efivar}
             echo "PlatformCompatSpec variable created"
         else

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-agx-orin-devkit
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-agx-orin-devkit
@@ -88,7 +88,7 @@ info "Bootloader blob is $bootloader_blob"
 do_capsule_update() {
     # Unzip capsule to the boot partition
     mkdir -p /mnt/boot/EFI/UpdateCapsule/
-    zcat ${bootloader_blob} > /mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+    gunzip -k -c ${bootloader_blob} | dd of=/mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
     sync
 
     if [ $(ls -l ${efivars_dir}OsIndications* | wc -l) -gt 0 ]; then
@@ -109,7 +109,7 @@ do_legacy_update() {
         info_log "Will clear bootloader device before the update"
         flash_erase /dev/mtd0 0 0 || true
         info_log "Updating bootloader device"
-        zcat $bootloader_blob > $bootloader_device
+        gunzip -k -c $bootloader_blob | dd of=$bootloader_device
         info_log "Updated bootloader device"
     else
         info_log "No need to update bootloader device"

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-orin-nano-devkit-nvme
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-orin-nano-devkit-nvme
@@ -65,7 +65,7 @@ info "Bootloader blob is $bootloader_blob"
 do_capsule_update() {
     # Unzip capsule to the boot partition
     mkdir -p /mnt/boot/EFI/UpdateCapsule/
-    zcat ${bootloader_blob} > /mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+    gunzip -k -c ${bootloader_blob} | dd of=/mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
     sync
 
     if [ $(ls -l ${efivars_dir}OsIndications* | wc -l) -gt 0 ]; then

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-orin-nx-xavier-nx-devkit
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-orin-nx-xavier-nx-devkit
@@ -70,7 +70,7 @@ info "Bootloader blob is $bootloader_blob"
 do_capsule_update() {
     # Unzip capsule to the boot partition
     mkdir -p /mnt/boot/EFI/UpdateCapsule/
-    zcat ${bootloader_blob} > /mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
+    gunzip -k -c ${bootloader_blob} | dd of=/mnt/boot/EFI/UpdateCapsule/TEGRA_BL.Cap
     sync
 
     if [ $(ls -l ${efivars_dir}OsIndications* | wc -l) -gt 0 ]; then

--- a/layers/meta-balena-jetson/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
+++ b/layers/meta-balena-jetson/recipes-support/resin-init/resin-init-flasher-board/resin-init-flasher-board
@@ -3,10 +3,10 @@
 set -e
 
 flash_erase /dev/mtd0 0 0
-zcat /opt/tegra-binaries/boot0.img.gz > /dev/mtdblock0
+gunzip -k -c /opt/tegra-binaries/boot0.img.gz | dd of=/dev/mtdblock0
 sync
 
-# Relocate secondary gpt after writing image to the emmc with dd
+# Relocate secondary gpt after writing image to the nvme with dd
 sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk /dev/nvme0n1
     v
     w


### PR DESCRIPTION
    when writing the TegraCompatSpec vars, similar to
    how meta-tegra's setup-nv-boot-control does. Previously
    we used the values generated by the tegra flashing tools
    in the Ubuntu root filesystem, prior to actually flashing
    the device.
    
    Although the generated contents are a bit different,
    both those and the ones generated at runtime by the meta-tegra
    scripts work, so let's use ones provided by the upstream
    yocto distribution.
    
    Signed-off-by: Alexandru Costache <alexandru@balena.io>
