### PR TITLE
linux-tegra: Enable binder config for Jetson Orin Nano

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -79,6 +79,14 @@ BALENA_CONFIGS[rtc] = " \
     CONFIG_RTC_SYSTOHC_DEVICE="rtc0" \
 "
 
+BALENA_CONFIGS:append:jetson-orin-nano-devkit-nvme = " binder"
+BALENA_CONFIGS[binder] = " \
+    CONFIG_ANDROID=y \
+    CONFIG_ANDROID_BINDER_IPC=y \
+    CONFIG_ANDROID_BINDER_DEVICES=\"binder,hwbinder,vndbinder\" \
+    CONFIG_ANDROID_BINDER_IPC_SELFTEST=y \
+"
+
 L4TVER=" l4tver=${L4T_VERSION}"
 
 KERNEL_ARGS = " firmware_class.path=/etc/firmware fbcon=map:0 "


### PR DESCRIPTION
As per zendesk ticket 2718. The config was previously enabled for the TX2 on L4T 32.X base-line, but the upstream 35.X did not enable it by default.

Changelog-entry: linux-tegra: Enable binder config for Jetson Orin Nano