### PR TITLE
linux-tegra: Enable CONFIG_ASHMEM

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -82,6 +82,7 @@ BALENA_CONFIGS[rtc] = " \
 BALENA_CONFIGS:append:jetson-orin-nano-devkit-nvme = " binder"
 BALENA_CONFIGS[binder] = " \
     CONFIG_ANDROID=y \
+    CONFIG_ASHMEM=y \
     CONFIG_ANDROID_BINDER_IPC=y \
     CONFIG_ANDROID_BINDER_DEVICES=\"binder,hwbinder,vndbinder\" \
     CONFIG_ANDROID_BINDER_IPC_SELFTEST=y \


### PR DESCRIPTION
This config may also be needed apart from
the BINDER configs.

Changelog-entry: linux-tegra: Enable CONFIG_ASHMEM