### PR TITLE
recipes-kernel/linux-tegra: Add Ilitek ILI210X based touchscreen kern…

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -79,7 +79,7 @@ BALENA_CONFIGS[rtc] = " \
     CONFIG_RTC_SYSTOHC_DEVICE="rtc0" \
 "
 
-BALENA_CONFIGS:append:jetson-orin-nano-devkit-nvme = " binder"
+BALENA_CONFIGS:append:jetson-orin-nano-devkit-nvme = " binder touchscreen"
 BALENA_CONFIGS[binder] = " \
     CONFIG_ANDROID=y \
     CONFIG_ASHMEM=y \
@@ -88,7 +88,11 @@ BALENA_CONFIGS[binder] = " \
     CONFIG_ANDROID_BINDER_IPC_SELFTEST=y \
 "
 
-BALENA_CONFIGS:append:jetson-orin-nano-4g-devkit = " binder"
+BALENA_CONFIGS[touchscreen] = " \
+    CONFIG_TOUCHSCREEN_ILI210X=m \
+"
+
+BALENA_CONFIGS:append:jetson-orin-nano-4g-devkit = " binder touchscreen"
 
 L4TVER=" l4tver=${L4T_VERSION}"
 


### PR DESCRIPTION
…el module

As per the internal thread: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/Enable.20Kernel.20config.20flag.20for.20nVidia.20Orin.20Nano.20devices/near/445604932

Changelog-entry: recipes-kernel/linux-tegra: Add Ilitek ILI210X based touchscreen kernel module