### PR TITLE
balena-image: Install linux-firmware-qca and linux-firmware-ath10k

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -25,6 +25,9 @@ IMAGE_INSTALL:append = " \
     linux-firmware-rtl8168 \
     linux-firmware-ibt-12-16 \
     linux-firmware-iwlwifi-8265 \
+    linux-firmware-ath10k \
+    linux-firmware-ath10k-license \
+    linux-firmware-qca \
     jetson-dtbs \
     l4t-launcher-extlinux \
     dtc \


### PR DESCRIPTION
These firmware files add a total of about 5MB to the root filesystem.

Changelog-entry: balena-image: Install linux-firmware-qca and linux-firmware-ath10k