### PR TITLE
.gitmodules: update poky branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "layers/poky"]
 	path = layers/poky
 	url = https://github.com/balena-os/poky.git
-	branch = backport_addpylib
+	branch = backport_addpylib_0ae3b2bd
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git

--- a/layers/meta-balena-jetson/recipes-bsp/uefi/files/Dockerfile
+++ b/layers/meta-balena-jetson/recipes-bsp/uefi/files/Dockerfile
@@ -2,7 +2,9 @@ FROM ghcr.io/tianocore/containers/ubuntu-22-dev:latest
 
 ARG DEVICE_TYPE
 
-RUN apt-get update && apt-get install git vim && \
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y git vim && \
     mkdir build && cd build && \
     edkrepo manifest-repos add nvidia https://github.com/NVIDIA/edk2-edkrepo-manifest.git main nvidia && \
     edkrepo clone nvidia-uefi NVIDIA-Platforms r36.3.0-updates


### PR DESCRIPTION
We are maintaining a fork of Poky and using a branch there as source as we need to backport a bitbake patch that is still not contained in the current Yocto LTS release.

The patch in question is:
https://github.com/balena-os/poky/commit/debd42be214be6bce50a0f0a2fe186b20e6fe6bc

This commit updates the branch to rebase that commit to the current kirkstone HEAD which includes security and bug fixes.

The old branch is maintained not to loose history, and a new branch has been preferred over a merge into the current one as that would only bury the backported patch making it more difficult to follow what the reasoning for the branch is.

Changelog-entry: Update Poky to kirkstone HEAD