### PR TITLE
recipes-kernel/linux: Add reComputer Industrial J4012 ethernet driver

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
@@ -93,6 +93,11 @@ BALENA_CONFIGS[binder] = " \
     CONFIG_ANDROID_BINDER_IPC_SELFTEST=y \
 "
 
+BALENA_CONFIGS:append:jetson-orin-nx-seeed-j4012 = " lan743x"
+BALENA_CONFIGS[lan743x] = " \
+    CONFIG_LAN743X=m \
+"
+
 BALENA_CONFIGS:append = " mtd nvme"
 BALENA_CONFIGS[mtd] = " \
     CONFIG_MTD_BLOCK=m \


### PR DESCRIPTION
Adds in the LAN743x driver for the non-PoE ethernet port on the Seeed Studio reComputer Industrial J4012