### PR TITLE
workflows: stop get_inputs job running on both PR and PRT triggers

### DIFF
--- a/.github/workflows/forecr-dsb-ornx-orin-nano-8gb.yml
+++ b/.github/workflows/forecr-dsb-ornx-orin-nano-8gb.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-agx-orin-devkit-64gb.yml
+++ b/.github/workflows/jetson-agx-orin-devkit-64gb.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-agx-orin-devkit.yml
+++ b/.github/workflows/jetson-agx-orin-devkit.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-orin-nano-devkit-nvme.yml
+++ b/.github/workflows/jetson-orin-nano-devkit-nvme.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-orin-nano-seeed-j3010.yml
+++ b/.github/workflows/jetson-orin-nano-seeed-j3010.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-orin-nx-seeed-j4012.yml
+++ b/.github/workflows/jetson-orin-nx-seeed-j4012.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:

--- a/.github/workflows/jetson-orin-nx-xavier-nx-devkit.yml
+++ b/.github/workflows/jetson-orin-nx-xavier-nx-devkit.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:


### PR DESCRIPTION
This stops an issue in the yocto-scripts workflow logic caused by get_inputs running twice on commits

Changelog-entry: workflows: stop get_inputs job running on both PR and PRT triggers