### PR TITLE
Load kernel modules + config for calico CNI

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
@@ -105,6 +105,23 @@ BALENA_CONFIGS[iwlwifi] = " \
     CONFIG_IWLMVM=m \
 "
 
+# Policy routing + IPIP + raw netfilter table — required by Calico CNI
+# for Kubernetes networking. Without IP_MULTIPLE_TABLES, `ip rule` returns
+# "Address family not supported by protocol". See
+# https://forums.balena.io/t/kenel-build-flags-for-networking-on-jetson-orin-series/375797
+BALENA_CONFIGS:append = " calico"
+BALENA_CONFIGS[calico] = " \
+    CONFIG_IP_ADVANCED_ROUTER=y \
+    CONFIG_IP_MULTIPLE_TABLES=y \
+    CONFIG_IP_NF_RAW=m \
+    CONFIG_NET_IPIP=m \
+"
+
+BALENA_CONFIGS:append = " wireguard"
+BALENA_CONFIGS[wireguard] = " \
+    CONFIG_WIREGUARD=m \
+"
+
 # Needed starting with Jetpack 6
 # so the initramfs can mount the
 # NVME partitions

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-jammy-nvidia-tegra_5.15.bbappend
@@ -105,15 +105,17 @@ BALENA_CONFIGS[iwlwifi] = " \
     CONFIG_IWLMVM=m \
 "
 
-# Policy routing + IPIP + raw netfilter table — required by Calico CNI
-# for Kubernetes networking. Without IP_MULTIPLE_TABLES, `ip rule` returns
-# "Address family not supported by protocol". See
-# https://forums.balena.io/t/kenel-build-flags-for-networking-on-jetson-orin-series/375797
+# Calico CNI kernel requirements
+# https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kernel-dependencies
+# Calico base: policy routing + iptables raw/mark/rpfilter.
+# IPIP overlay support.
 BALENA_CONFIGS:append = " calico"
 BALENA_CONFIGS[calico] = " \
     CONFIG_IP_ADVANCED_ROUTER=y \
     CONFIG_IP_MULTIPLE_TABLES=y \
     CONFIG_IP_NF_RAW=m \
+    CONFIG_IP_NF_MATCH_RPFILTER=m \
+    CONFIG_NETFILTER_XT_MATCH_MARK=m \
     CONFIG_NET_IPIP=m \
 "
 


### PR DESCRIPTION
Referring to https://forums.balena.io/t/kenel-build-flags-for-networking-on-jetson-orin-series/375797

This PR loads networking kernel modules needed to support IPv4 policy based routing on the orin-series devices, as needed for the calico kubernetes CNI. https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kernel-dependencies.

Technically, only `CONFIG_IP_ADVANCED_ROUTER=y` and `CONFIG_IP_MULTIPLE_TABLES=y` are strictly required here.

It's possible to build the modules externally for CONFIG_IP_NF_RAW, CONFIG_IP_NF_MATCH_RPFILTER, CONFIG_NETFILTER_XT_MATCH_MARK, CONFIG_NET_IPIP, and CONFIG_WIREGUARD.

However, the jetson-nano and xavier OS's already include all of these except CONFIG_NET_IPIP, and CONFIG_WIREGUARD
And the raspberry pi images have all of it.

So my thought is that it isn't unreasonable to build all of them for consistency.
I have confirmed that this change builds correctly, and the built image solves my issue on the AGX Orin.

And of course, I'm happy to take feedback here.

Thanks!
-Mike