### PR TITLE
.gitmodules and workflows: Declare submodule branches, forward meta-balena-ref

### DIFF
--- a/.github/workflows/forecr-dsb-ornx-orin-nano-8gb.yml
+++ b/.github/workflows/forecr-dsb-ornx-orin-nano-8gb.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-agx-orin-devkit-64gb.yml
+++ b/.github/workflows/jetson-agx-orin-devkit-64gb.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-agx-orin-devkit.yml
+++ b/.github/workflows/jetson-agx-orin-devkit.yml
@@ -115,3 +115,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-orin-nano-devkit-nvme.yml
+++ b/.github/workflows/jetson-orin-nano-devkit-nvme.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-orin-nano-seeed-j3010.yml
+++ b/.github/workflows/jetson-orin-nano-seeed-j3010.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-orin-nx-seeed-j4012.yml
+++ b/.github/workflows/jetson-orin-nx-seeed-j4012.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.github/workflows/jetson-orin-nx-xavier-nx-devkit.yml
+++ b/.github/workflows/jetson-orin-nx-xavier-nx-devkit.yml
@@ -113,3 +113,5 @@ jobs:
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "layers/meta-tegra"]
 	path = layers/meta-tegra
 	url = https://github.com/OE4T/meta-tegra.git
-	branch = master
+	branch = wrynose
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
@@ -25,9 +25,12 @@
 [submodule "layers/meta-yocto"]
 	path = layers/meta-yocto
 	url = https://git.yoctoproject.org/meta-yocto
+	branch = master
 [submodule "layers/bitbake"]
 	path = layers/bitbake
 	url = https://git.openembedded.org/bitbake
+	branch = master
 [submodule "layers/openembedded-core"]
 	path = layers/openembedded-core
 	url = https://git.openembedded.org/openembedded-core
+	branch = master


### PR DESCRIPTION
Two unrelated fixes, combined so one CI run covers both.

**`.gitmodules`** — `check_gitmodules_branches` fails while any submodule has no
branch declared. 3 had none, and `meta-tegra` declared a branch that does not
contain its pin.

| Submodule | Branch | Basis |
|---|---|---|
| `layers/openembedded-core` | `master` | ancestor. This repo uses a split poky rather than the poky submodule |
| `layers/bitbake` | `master` | ancestor |
| `layers/meta-yocto` | `master` | ancestor |
| `layers/meta-tegra` | `master` &rarr; `wrynose` | the pin is on `wrynose`, not `master` |

**Workflows** — every board workflow declared `meta-balena-ref` as a
`workflow_call` input but never forwarded it to `yocto-build-deploy`, so callers
that set it got it silently dropped. That is why meta-balena#3935 fails on
jetson-orin boards and passes elsewhere: those builds used the meta-balena
pinned here instead of the one in the PR. raspberrypi, generic, compulab-imx8mp,
compulab-imx9, fsl-arm and up-board already forward it; this matches them.
