### PR TITLE
Fix `migrate:force` for single-disk provisioning

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/uefi-capsule-container_39.2.0.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/uefi-capsule-container_39.2.0.bb
@@ -4,13 +4,13 @@ require recipes-bsp/tegra-binaries/tegra-binaries-${PV}.inc
 
 inherit deploy l4t_bsp
 
-JETSON_BOARD_SPEC:jetson-orin-nano-devkit-nvme="jetson_board_spec_nano.cfg"
-JETSON_BOARD_SPEC:jetson-orin-nx-xavier-nx-devkit="jetson_board_spec_nx.cfg"
-JETSON_BOARD_SPEC:jetson-agx-orin-devkit="jetson_board_spec_agx_32gb.cfg"
-JETSON_BOARD_SPEC:jetson-agx-orin-devkit-64gb="jetson_board_spec_agx_64gb.cfg"
-JETSON_BOARD_SPEC:jetson-orin-nano-seeed-j3010="jetson_board_spec_j3010_j4012.cfg"
-JETSON_BOARD_SPEC:jetson-orin-nx-seeed-j4012="jetson_board_spec_j3010_j4012.cfg"
-JETSON_BOARD_SPEC:forecr-dsb-ornx-orin-nano-8gb="jetson_board_spec_forecr.cfg"
+JETSON_BOARD_SPEC:jetson-orin-nano-devkit-nvme = "jetson_board_spec_nano.cfg"
+JETSON_BOARD_SPEC:jetson-orin-nx-xavier-nx-devkit = "jetson_board_spec_nx.cfg"
+JETSON_BOARD_SPEC:jetson-agx-orin-devkit = "jetson_board_spec_agx_32gb.cfg"
+JETSON_BOARD_SPEC:jetson-agx-orin-devkit-64gb = "jetson_board_spec_agx_64gb.cfg"
+JETSON_BOARD_SPEC:jetson-orin-nano-seeed-j3010 = "jetson_board_spec_j3010_j4012.cfg"
+JETSON_BOARD_SPEC:jetson-orin-nx-seeed-j4012 = "jetson_board_spec_j3010_j4012.cfg"
+JETSON_BOARD_SPEC:forecr-dsb-ornx-orin-nano-8gb = "jetson_board_spec_forecr.cfg"
 
 SRC_URI = " \
     file://Dockerfile \
@@ -101,11 +101,11 @@ do_compile[depends] += " edk2-firmware-tegra:do_deploy edk2-nvidia-standalone-mm
 do_convert_crlf_to_lf[depends] += " tegra-binaries:do_patch "
 addtask do_deploy before do_package after do_install
 
-# redefine the global reproducible-build function as a no-op
+# Redefine the global reproducible-build function as a no-op
 # for this recipe to prevent shared-work directory race conditions.
 python create_source_date_epoch_stamp() {
     pass
 }
 
-# fix QA Issue: File ... TEGRA_BL.Cap contains reference to TMPDIR
+# Fixes QA Issue: File ... TEGRA_BL.Cap contains reference to TMPDIR
 INSANE_SKIP:${PN} += "buildpaths"

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -21,7 +21,7 @@ PACKAGE_INSTALL:append = " kernel-module-phy-tegra194-p2u"
 # allow access to the QSPI, but install the qspi driver
 # in case it is accessible
 PACKAGE_INSTALL:append = " mtd-utils fatrw gptfdisk kernel-module-spi-tegra210-quad"
-PACKAGE_INSTALL:append = " mtd-utils fatrw gptfdisk kernel-module-spi-tegra210-quad jetson-qspi-manager setup-nv-boot-control"
+PACKAGE_INSTALL:append = " mtd-utils fatrw gptfdisk kernel-module-spi-tegra210-quad jetson-qspi-manager setup-nv-boot-control tegra-redundant-boot-base"
 # Below modules are needed for the AGX Orin 64GB to
 # detect USB keys
 PACKAGE_INSTALL:append:jetson-agx-orin-devkit-64gb = " kernel-module-typec-ucsi"

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-noble-nvidia-tegra_6.8.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-noble-nvidia-tegra_6.8.bbappend
@@ -257,17 +257,17 @@ KERNEL_ARGS += "${@bb.utils.contains('DISTRO_FEATURES','osdev-image',' mminit_lo
 
 # Let's not disable this by default
 # in our integration, although upstream does.
-KERNEL_ARGS:remove="nospectre_bhb"
+KERNEL_ARGS:remove = "nospectre_bhb"
 KERNEL_ARGS:remove="firmware_class.path=/etc/firmware"
 
-DEFAULT_SEEED_OVERLAYS=",/boot/devicetree/tegra234-dcb-p3767-0000-hdmi.dtbo,/boot/devicetree/tegra234-p3767-camera-p3768-imx219-dual-seeed.dtbo"
+DEFAULT_SEEED_OVERLAYS = ",/boot/devicetree/tegra234-dcb-p3767-0000-hdmi.dtbo,/boot/devicetree/tegra234-p3767-camera-p3768-imx219-dual-seeed.dtbo"
 
-DTB_OVERLAYS:jetson-agx-orin-devkit-64gb="/boot/devicetree/tegra234-p3737-0000+p3701-0000-dynamic.dtbo"
-DTB_OVERLAYS:jetson-agx-orin-devkit="/boot/devicetree/tegra234-p3737-0000+p3701-0000-dynamic.dtbo"
-DTB_OVERLAYS="/boot/devicetree/tegra234-p3768-0000+p3767-0000-dynamic.dtbo"
-DTB_OVERLAYS:append:jetson-orin-nano-seeed-j3010="${DEFAULT_SEEED_OVERLAYS}"
-DTB_OVERLAYS:append:jetson-orin-nx-seeed-j4012="${DEFAULT_SEEED_OVERLAYS}"
-DTB_OVERLAYS:append:jetson-orin-nano-devkit-nvme=",/boot/devicetree/tegra234-p3767-camera-p3768-imx219-dual.dtbo"
+DTB_OVERLAYS:jetson-agx-orin-devkit-64gb = "/boot/devicetree/tegra234-p3737-0000+p3701-0000-dynamic.dtbo"
+DTB_OVERLAYS:jetson-agx-orin-devkit = "/boot/devicetree/tegra234-p3737-0000+p3701-0000-dynamic.dtbo"
+DTB_OVERLAYS = "/boot/devicetree/tegra234-p3768-0000+p3767-0000-dynamic.dtbo"
+DTB_OVERLAYS:append:jetson-orin-nano-seeed-j3010 = "${DEFAULT_SEEED_OVERLAYS}"
+DTB_OVERLAYS:append:jetson-orin-nx-seeed-j4012 = "${DEFAULT_SEEED_OVERLAYS}"
+DTB_OVERLAYS:append:jetson-orin-nano-devkit-nvme = ",/boot/devicetree/tegra234-p3767-camera-p3768-imx219-dual.dtbo"
 
 # Switch some configs to modules so they can be compressed,
 # and disable the ones which are not present on the Orins.

--- a/layers/meta-balena-jetson/recipes-support/jetson-qspi-manager/jetson-qspi-manager/jetson-qspi-helpers
+++ b/layers/meta-balena-jetson/recipes-support/jetson-qspi-manager/jetson-qspi-manager/jetson-qspi-helpers
@@ -79,8 +79,16 @@ write_jetson_update_efivars() {
 
 # $1 - target path for unpacking UEFI capsule
 prepare_capsule() {
-    uefi_capsule=$(find / -xdev -type f -name "TEGRA_BL*.Cap.gz")
-
+    # See meta-balena commit 7741fcee4b3
+    # Check /tmp separately from /, as when migrating, we have the UEFI capsule copied to
+    # a separate filesystem, and -xdev prohibits crossing filesystem boundaries
+    uefi_capsule=$(find /tmp -xdev -type f -name "TEGRA_BL*.Cap.gz")
+    if [ ! -f "${uefi_capsule}" ]; then
+        uefi_capsule=$(find / -xdev -type f -name "TEGRA_BL*.Cap.gz")
+        if [ ! -f "${uefi_capsule}" ]; then
+            fail "UEFI capsule not found in rootfs nor in /tmp/"
+        fi
+    fi
     # Use boot partition during provisioning
     # since it is already mounted when called from initramfs
     # and has the esp flags


### PR DESCRIPTION
This PR installs nvbootctrl in the initramfs and also adds /tmp/ as a search path, because the UEFI capsule is copied in zram
when provisioning single disk systems, i.e when migrate:force is used on an sd-card.

Tested on Jetson Orin Nano Devkit using an SD-card as install & boot media.

Fixes Zendesk ticket 6638